### PR TITLE
half.h: Add missing #includes.

### DIFF
--- a/datraw/datraw/half.h
+++ b/datraw/datraw/half.h
@@ -8,7 +8,9 @@
 #define _DATRAW_HALF_H
 #pragma once
 
+#include <cassert>
 #include <cinttypes>
+#include <cmath>
 #include <cstring>
 #include <cstdint>
 #include <limits>


### PR DESCRIPTION
These #includes are needed for std::fabs(..) and assert(..). Tested on Linux, CMake 4.3.1, GCC 15.2.1.